### PR TITLE
added packages for circular statistics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
+# R files
 .Rproj.user
 .Rhistory
 .RData
 *.html
 *.Rproj
+
+# GNUEmacs backup
+*~

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Dissimilarity coefficients
 -	  [G2Sd](http://cran.rstudio.com/web/packages/G2Sd/index.html) gives full descriptive statistics and a physical description of sediments based on grain-size distributions, [soiltexture](http://cran.rstudio.com/web/packages/soiltexture/index.html) and [ggtern](http://cran.rstudio.com/web/packages/ggtern/index.html) for ternary plots of soil texture
 -	   Constrained clustering of stratigraphic data is provided by function `chclust()` in the form of constrained hierarchical clustering in [rioja](http://cran.rstudio.com/web/packages/rioja/index.html).
 -	   Stratigraphic columns can be plotted and analysed with the the [SDAR](http://run.unl.pt/bitstream/10362/14554/1/TGEO0128.pdf) package. 
+-	Function for circular statistics can be found in [CircStats](https://cran.r-project.org/web/packages/CircStats/index.html), [RFOC](https://cran.rstudio.com/web/packages/RFOC/index.html) and [heR.Misc](http://exposurescience.org/hosted-projects/inhalation-exposure-simulation-modeling-project/the-her-software-project)
 -    Radiocarbon dates can be calibrated using [Bchron](http://cran.rstudio.com/web/packages/Bchron/index.html) with various calibration curves (including user generated ones); also does Age-depth modelling, relative sea level rate estimation incorporating time uncertainty in polynomial regression models; and non-parametric phase modelling via Gaussian mixtures as a means to determine the activity of a site (and as an alternative to the Oxcal function SUM). The [roxcal](https://github.com/MartinHinz/roxcal) package allows you to use R to connect to a local installation of the OxCal software to calibrate radiocarbon dates and a variety of other OxCal operations. 
 -    Various R functions for Luminescence Dating data analysis are in the [Luminescence](http://cran.rstudio.com/web/packages/Luminescence/index.html) package (including radial plotting) and in the [numOSL](https://cran.r-project.org/web/packages/numOSL/index.html) package.
 -    Functions for tree ring analysis can be found in [dplR](http://cran.rstudio.com/web/packages/dplR/index.html)
@@ -273,4 +274,4 @@ Shennan, SJ, Enrico R. Crema, Tim Kerig, (2014) Isolation-by-distance, homophily
 
 #### Contributors
 
-Ben Marwick, Agustin Diez Castillo, Allar Haav, Sebastian Heath, Phil Riris, Tom Brughmans, Lee Drake, Stefano Costa, Enrico Crema, Domenico Giusti, Matt Peeples, Mark Madsen, Daniel Contreras, [Tal Galili](https://github.com/talgalili)
+Ben Marwick, Agustin Diez Castillo, Allar Haav, Sebastian Heath, Phil Riris, Tom Brughmans, Lee Drake, Stefano Costa, Enrico Crema, [Domenico Giusti](https://github.com/dncgst), Matt Peeples, Mark Madsen, Daniel Contreras, [Tal Galili](https://github.com/talgalili)


### PR DESCRIPTION
Fabric analysis has an important role in the study of site formation processes (see Bertran&Texier1995, Lenoble&Bertran2004, McPherron2005, Dominguez-Rodrigo et al.2012, among others). I'm currently using these packages. Please note that installing heR.Misc you get an ERROR: a 'NAMESPACE' file is required.

Here's the solution:
http://stackoverflow.com/questions/17196225/error-a-namespace-file-is-required
Untar the package:
`tar -xvf the_package.tar.gz`
Add a NAMESPACE file with the line exportPattern( "." ):
`cd the_package`
`echo 'exportPattern( "." )' > NAMESPACE`
`cd ..`
Re-tar the package:
`tar -zcf the_package.tar.gz the_package`